### PR TITLE
bluetooth: l2cap: receive server error status

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2359,7 +2359,7 @@ static void l2cap_chan_le_recv(struct bt_l2cap_le_chan *chan,
 	}
 
 	err = chan->chan.ops->recv(&chan->chan, buf);
-	if (err) {
+	if (err < 0) {
 		if (err != -EINPROGRESS) {
 			BT_ERR("err %d", err);
 			bt_l2cap_chan_disconnect(&chan->chan);


### PR DESCRIPTION
Only consider negative statuses returned from a L2CAP server as error.

This makes the status check done here consistent with the check done in
l2cap_chan_le_recv_sdu.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>